### PR TITLE
pinboard-wizard: update to v0.2.0

### DIFF
--- a/Casks/pinboard-wizard.rb
+++ b/Casks/pinboard-wizard.rb
@@ -1,8 +1,8 @@
 cask 'pinboard-wizard' do
-  version '0.1.0'
-  sha256 '99ccb1fca86de6baa93e0bb1341c9be88bd6bf188a59ac522a097e918f525b1b'
+  version '0.2.0'
+  sha256 'sha256:441bd4a9a7de43fe6944d40ddb9b9888372a7a3c8cdcca4ecdbdca4d9d1da847'
 
-  url 'https://github.com/RikuVan/pinboard_wizard/releases/download/v0.1.0/pinboard-wizard-v0.1.0-macos.tar.gz'
+  url 'https://github.com/RikuVan/pinboard_wizard/releases/download/v0.2.0/pinboard_wizard.zip'
   name 'Pinboard Wizard'
   desc 'A macOS client for Pinboard.in built with AI support and backups'
   homepage 'https://github.com/RikuVan/pinboard_wizard'


### PR DESCRIPTION
Update pinboard-wizard cask to version **0.2.0**.

- URL: https://github.com/RikuVan/pinboard_wizard/releases/download/v0.2.0/pinboard_wizard.zip
- SHA256: `sha256:441bd4a9a7de43fe6944d40ddb9b9888372a7a3c8cdcca4ecdbdca4d9d1da847`

Automated PR.