### PR TITLE
pinboard-wizard: update to v0.3.0

### DIFF
--- a/Casks/pinboard-wizard.rb
+++ b/Casks/pinboard-wizard.rb
@@ -1,8 +1,8 @@
 cask 'pinboard-wizard' do
-  version '0.2.0'
-  sha256 '441bd4a9a7de43fe6944d40ddb9b9888372a7a3c8cdcca4ecdbdca4d9d1da847'
+  version '0.3.0'
+  sha256 "b098ca99f6aa1ca65937d31acaff4593c5e31e72b501a905c1b0b738e83fc5b8"
 
-  url 'https://github.com/RikuVan/pinboard_wizard/releases/download/v0.2.0/pinboard_wizard.zip'
+  url 'https://github.com/RikuVan/pinboard_wizard/releases/download/v0.3.0/pinboard_wizard.zip'
   name 'Pinboard Wizard'
   desc 'A macOS client for Pinboard.in built with AI support and backups'
   homepage 'https://github.com/RikuVan/pinboard_wizard'


### PR DESCRIPTION
Update pinboard-wizard cask to version **0.3.0**.

- URL: https://github.com/RikuVan/pinboard_wizard/releases/download/v0.3.0/pinboard_wizard.zip
- SHA256: `b098ca99f6aa1ca65937d31acaff4593c5e31e72b501a905c1b0b738e83fc5b8`

Automated PR.