### PR TITLE
pinboard-wizard: update to v0.5.0

### DIFF
--- a/Casks/pinboard-wizard.rb
+++ b/Casks/pinboard-wizard.rb
@@ -1,8 +1,8 @@
 cask 'pinboard-wizard' do
-  version '0.4.0'
-  sha256 "d4b766e9088bc58c1f9fd2e675b62cb61b04271da067cd85f27c563e7933ddfd"
+  version '0.5.0'
+  sha256 "fa4fb4c51e4bb7565433b42590d5462d2359279991eb7346442a62dea8479c0f"
 
-  url 'https://github.com/RikuVan/pinboard_wizard/releases/download/v0.4.0/pinboard_wizard.zip'
+  url 'https://github.com/RikuVan/pinboard_wizard/releases/download/v0.5.0/pinboard_wizard.zip'
   name 'Pinboard Wizard'
   desc 'A macOS client for Pinboard.in built with AI support and backups'
   homepage 'https://github.com/RikuVan/pinboard_wizard'


### PR DESCRIPTION
Update pinboard-wizard cask to version **0.5.0**.

- URL: https://github.com/RikuVan/pinboard_wizard/releases/download/v0.5.0/pinboard_wizard.zip
- SHA256: `fa4fb4c51e4bb7565433b42590d5462d2359279991eb7346442a62dea8479c0f`

Automated PR.