### PR TITLE
pinboard-wizard: update to v0.5.0

### DIFF
--- a/Casks/pinboard-wizard.rb
+++ b/Casks/pinboard-wizard.rb
@@ -1,8 +1,8 @@
 cask 'pinboard-wizard' do
-  version '0.4.0'
-  sha256 "d4b766e9088bc58c1f9fd2e675b62cb61b04271da067cd85f27c563e7933ddfd"
+  version '0.5.0'
+  sha256 "8ea920ebb1ec2c22801b04976574c6c9e827ce76d47c9a771902ed77f03ab2a6"
 
-  url 'https://github.com/RikuVan/pinboard_wizard/releases/download/v0.4.0/pinboard_wizard.zip'
+  url 'https://github.com/RikuVan/pinboard_wizard/releases/download/v0.5.0/pinboard_wizard.zip'
   name 'Pinboard Wizard'
   desc 'A macOS client for Pinboard.in built with AI support and backups'
   homepage 'https://github.com/RikuVan/pinboard_wizard'


### PR DESCRIPTION
Update pinboard-wizard cask to version **0.5.0**.

- URL: https://github.com/RikuVan/pinboard_wizard/releases/download/v0.5.0/pinboard_wizard.zip
- SHA256: `8ea920ebb1ec2c22801b04976574c6c9e827ce76d47c9a771902ed77f03ab2a6`

Automated PR.