### PR TITLE
pinboard-wizard: update to v0.7.0

### DIFF
--- a/Casks/pinboard-wizard.rb
+++ b/Casks/pinboard-wizard.rb
@@ -1,8 +1,8 @@
 cask 'pinboard-wizard' do
-  version '0.6.0'
-  sha256 "753aa9521e9be1a7b355a2d76db903f4d83be6b9d2df5755eec2dd9342301541"
+  version '0.7.0'
+  sha256 "480ac054e8445548020fba490d0773c96922121fbe841cdb16009e4d5623e05e"
 
-  url 'https://github.com/RikuVan/pinboard_wizard/releases/download/v0.6.0/pinboard_wizard.zip'
+  url 'https://github.com/RikuVan/pinboard_wizard/releases/download/v0.7.0/pinboard_wizard.zip'
   name 'Pinboard Wizard'
   desc 'A macOS client for Pinboard.in built with AI support and backups'
   homepage 'https://github.com/RikuVan/pinboard_wizard'


### PR DESCRIPTION
Update pinboard-wizard cask to version **0.7.0**.

- URL: https://github.com/RikuVan/pinboard_wizard/releases/download/v0.7.0/pinboard_wizard.zip
- SHA256: `480ac054e8445548020fba490d0773c96922121fbe841cdb16009e4d5623e05e`

Automated PR.