### PR TITLE
pinboard-wizard: update to v0.7.1

### DIFF
--- a/Casks/pinboard-wizard.rb
+++ b/Casks/pinboard-wizard.rb
@@ -1,8 +1,8 @@
 cask 'pinboard-wizard' do
-  version '0.7.0'
-  sha256 "480ac054e8445548020fba490d0773c96922121fbe841cdb16009e4d5623e05e"
+  version '0.7.1'
+  sha256 "0afbeb751ac2c8c535165060772fc1cfd9ed99abe3ddaf7044e59ebcfcb695a2"
 
-  url 'https://github.com/RikuVan/pinboard_wizard/releases/download/v0.7.0/pinboard_wizard.zip'
+  url 'https://github.com/RikuVan/pinboard_wizard/releases/download/v0.7.1/pinboard_wizard.zip'
   name 'Pinboard Wizard'
   desc 'A macOS client for Pinboard.in built with AI support and backups'
   homepage 'https://github.com/RikuVan/pinboard_wizard'


### PR DESCRIPTION
Update pinboard-wizard cask to version **0.7.1**.

- URL: https://github.com/RikuVan/pinboard_wizard/releases/download/v0.7.1/pinboard_wizard.zip
- SHA256: `0afbeb751ac2c8c535165060772fc1cfd9ed99abe3ddaf7044e59ebcfcb695a2`

Automated PR.